### PR TITLE
Get service count from search API

### DIFF
--- a/fetch-counts.js
+++ b/fetch-counts.js
@@ -1,13 +1,7 @@
 const fetch = require('node-fetch');
 
-fetch('https://aws.amazon.com/')
-    .then(res => res.text())
+fetch('https://aws.amazon.com/api/dirs/items/search?item.directoryId=aws-products&item.locale=en_US&tags.id=!aws-products%23type%23feature&tags.id=!aws-products%23type%23variant')
+    .then(res => res.json())
     .then(body => {
-        let bodySplit = body.split("lb-content-item");
-        let items = [];
-        bodySplit.forEach((item, i) => {if (i > 0 && i < bodySplit.length - 1) items.push(item);});
-        items = items.map(item => item.split('<span>')[0])
-        items = items.map(item => item.split('so-exp=below"> ')[1]);
-        
-        console.log(items.length);
+        console.log(body.metadata.totalHits);
     }).catch(err => console.log(err))


### PR DESCRIPTION
Hey Patrick!

It looks like AWS updated their homepage UI, so it's no longer possible to count the ridiculous number of services they have by examining the HTML. Fortunately, their products page has a search field that includes a count of the total number of results.

```sh
curl --silent 'https://aws.amazon.com/api/dirs/items/search?item.directoryId=aws-products&item.locale=en_US&tags.id=!aws-products%23type%23feature&tags.id=!aws-products%23type%23variant' | jq ".metadata.totalHits"
# 227
```

I haven't tested this code and I'm not sure which of the three copies of `fetch-counts.js` to modify, but if you feel like updating https://howmanyaws.com/ so developers can once again gawk at the big number, here's a fix.